### PR TITLE
pydriver: Make print-out of installed-drivers nice.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -346,6 +346,17 @@ version = "1.14.0"
 
 [[package]]
 category = "main"
+description = "Pretty-print tabular data"
+name = "tabulate"
+optional = false
+python-versions = "*"
+version = "0.8.6"
+
+[package.extras]
+widechars = ["wcwidth"]
+
+[[package]]
+category = "main"
 description = "ANSII Color formatting for output in terminal."
 name = "termcolor"
 optional = false
@@ -411,7 +422,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools"]
 
 [metadata]
-content-hash = "a383700a57307280758170de90652ef89f182f82d27d4907ef0c13376ca74dac"
+content-hash = "03f872f7b988464416975a37c64e475f9cbf7c823d0d0f14333f67ec22380a38"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -571,6 +582,9 @@ requests = [
 six = [
     {file = "six-1.14.0-py2.py3-none-any.whl", hash = "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"},
     {file = "six-1.14.0.tar.gz", hash = "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a"},
+]
+tabulate = [
+    {file = "tabulate-0.8.6.tar.gz", hash = "sha256:5470cc6687a091c7042cee89b2946d9235fe9f6d49c193a4ae2ac7bf386737c8"},
 ]
 termcolor = [
     {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ packaging = "^20.1"
 humanfriendly = "^6.1"
 configobj = "^5.0.6"
 requests = "^2.23.0"
+tabulate = "^0.8.6"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
List of installed drivers and available drivers is now printed
as table using python's external library. Also simplified sorting
versions using `LooseVersion`.

Fixes: #9