### PR TITLE
fix(ci): fix SV workflow run for every branch

### DIFF
--- a/.github/workflows/sv.yaml
+++ b/.github/workflows/sv.yaml
@@ -1,13 +1,14 @@
 name: Submit Verification Pydriver
 
 on:
-  push:
+  pull_request:
     branches:
       - master
+    types: [closed]
 
 jobs:
   build:
-
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
SV workflow should be run only on push to master (after PR merge)
but it was run with push to every branch although configuration
was valid according to Github docs.

Current solution is sort of workaround. SV is run on closing PR
but deleting PR also generates close action. In order to assure
workflow is run only for merged PR additional condition on job
level is introduced. Solution taken from:
https://github.community/t/trigger-workflow-only-on-pull-request-merge/17359/9

Fixes: #30