### PR TITLE
feature: Add yaspin spinner for cli commands

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -562,10 +562,21 @@ category = "dev"
 optional = false
 python-versions = "*"
 
+[[package]]
+name = "yaspin"
+version = "2.0.0"
+description = "Yet Another Terminal Spinner"
+category = "main"
+optional = false
+python-versions = ">=3.6.2,<4.0.0"
+
+[package.dependencies]
+termcolor = ">=1.1.0,<2.0.0"
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "b378200797502573cfcd279ace8b167c0bbb0182765d41c19ea997d4352fa6c5"
+content-hash = "d9219817ab46540a244a0fa2498b8b4249f15e729cc85f6080573f3bfcdf723d"
 
 [metadata.files]
 appdirs = [
@@ -873,4 +884,8 @@ win32-setctime = [
 ]
 wrapt = [
     {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},
+]
+yaspin = [
+    {file = "yaspin-2.0.0-py3-none-any.whl", hash = "sha256:9da195db6630b76f0d37612f195dd7c325e280ad398dae4fcf30890a124ceb74"},
+    {file = "yaspin-2.0.0.tar.gz", hash = "sha256:0498039b3e110f53824417a9f59418a20843e8752b8b15c26bb81a659d4aec5c"},
 ]

--- a/pydriver/chromedriver.py
+++ b/pydriver/chromedriver.py
@@ -1,9 +1,8 @@
 import re
 import xml.etree.ElementTree as ET
 
-from loguru import logger
-
 from pydriver.config import WebDriverType
+from pydriver.custom_logger import logger
 from pydriver.downloader import Downloader
 from pydriver.webdriver import WebDriver
 

--- a/pydriver/custom_logger.py
+++ b/pydriver/custom_logger.py
@@ -1,0 +1,73 @@
+import sys
+from contextlib import contextmanager
+
+import loguru
+from yaspin import yaspin
+
+__all__ = ["logger"]
+
+
+class __MyLogger:
+    """Logger class that combine luguru with yaspin for writing during spinner"""
+
+    __GREEN = "\033[0;32m%s\033[0m"
+
+    def __init__(self):
+        self.loguru_ = loguru.logger
+        self.sp = yaspin()
+        self.sp.color = "green"
+
+    def info(self, msg: str) -> None:
+        """
+        Hide spinner and execute loguru.info
+
+        :param msg: Message for loguru.info
+        """
+        with self.sp.hidden():
+            self.loguru_.info(msg)
+
+    def debug(self, msg: str) -> None:
+        """
+        Hide spinner and execute loguru.debug
+
+        :param msg: Message for loguru.debug
+        """
+        with self.sp.hidden():
+            self.loguru_.debug(msg)
+
+    def error(self, msg: str) -> None:
+        """
+        Hide spinner and execute loguru.error
+
+        :param msg: Message for loguru.error
+        """
+        with self.sp.hidden():
+            self.loguru_.error(msg)
+
+    def configure(self, **kwargs: dict) -> None:
+        """
+        Configure loguru
+
+        :param kwargs: Dictionary with loguru config
+        """
+        self.loguru_.configure(**kwargs)
+
+    @contextmanager
+    def spinner(self, msg: str) -> None:
+        """
+        Context manager to show spinner with given message
+        :param msg: Message to be visible together with spinner
+        """
+        self.sp.text = msg
+        self.sp.start()
+        try:
+            yield
+            self.sp.green.ok("✔ ")
+        except SystemExit as e:
+            self.sp.red.fail("❌ ")
+            sys.exit(e)
+        finally:
+            self.sp.stop()
+
+
+logger = __MyLogger()

--- a/pydriver/downloader.py
+++ b/pydriver/downloader.py
@@ -2,8 +2,8 @@ import shutil
 from pathlib import Path
 
 import requests
-from loguru import logger
 
+from pydriver.custom_logger import logger
 from pydriver.support import Support
 
 

--- a/pydriver/edgedriver.py
+++ b/pydriver/edgedriver.py
@@ -1,9 +1,8 @@
 import re
 import xml.etree.ElementTree as ET
 
-from loguru import logger
-
 from pydriver.config import WebDriverType
+from pydriver.custom_logger import logger
 from pydriver.downloader import Downloader
 from pydriver.webdriver import WebDriver
 

--- a/pydriver/geckodriver.py
+++ b/pydriver/geckodriver.py
@@ -1,9 +1,8 @@
 import re
 from typing import Dict
 
-from loguru import logger
-
 from pydriver.config import WebDriverType
+from pydriver.custom_logger import logger
 from pydriver.githubapi import GithubApi
 from pydriver.webdriver import WebDriver
 

--- a/pydriver/githubapi.py
+++ b/pydriver/githubapi.py
@@ -1,5 +1,4 @@
-from loguru import logger
-
+from pydriver.custom_logger import logger
 from pydriver.downloader import Downloader
 from pydriver.pydriver_types import ReleasesInfo
 

--- a/pydriver/operadriver.py
+++ b/pydriver/operadriver.py
@@ -1,9 +1,8 @@
 import re
 from typing import Dict
 
-from loguru import logger
-
 from pydriver.config import WebDriverType
+from pydriver.custom_logger import logger
 from pydriver.githubapi import GithubApi
 from pydriver.webdriver import WebDriver
 

--- a/pydriver/support.py
+++ b/pydriver/support.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from typing import List
 
 import humanfriendly
-from loguru import logger
 
+from pydriver.custom_logger import logger
 from pydriver.pydriver_types import Messages
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ junit_family = "xunit2"
 name = "pydriver"
 version = "0.2.0"
 description = "Download selenium WebDriver for Windows, Mac & Linux"
-authors = ["Krzysztof Czeronko <krzysztof.czeronko@gmail.com>"]
+authors = ["Krzysztof Czeronko <krzysztof.czeronko@gmail.com>", "Bartosz Sypniewski <bartosz.sypniewski@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.scripts]
@@ -43,6 +43,7 @@ tabulate = "^0.8.7"
 configobj = "^5.0.6"
 click = "^7.1.2"
 loguru = "^0.5.3"
+yaspin = "^2.0.0"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.4.4"


### PR DESCRIPTION
Add spinner based on yaspin on all command line executions

Add custom logger, to use loguru when spinner is visible (both cannot print in the same time)
Replace all loguru with custem_logger
Catch system.exit and raise it from custom_logger so spinner can be ended and hidden

Fixes: #11